### PR TITLE
installation: addition of missing `config.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,6 @@
 *.pyo
 __pycache__/
 
-# local configuration
-config.py
-
 #sublime configuration files
 *.sublime-project
 *.sublime-workspace

--- a/.kwalitee.yml
+++ b/.kwalitee.yml
@@ -2,5 +2,6 @@ components:
 - docker
 - docs
 - global
+- installation
 - tests
 - travis

--- a/config.py
+++ b/config.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of ClaimStore.
+# Copyright (C) 2015 CERN.
+#
+# ClaimStore is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# ClaimStore is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ClaimStore; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307,
+# USA.
+
+"""ClaimStore configuration."""
+
+import os
+
+# Statement for enabling the development environment
+DEBUG = True
+
+# Define the application directory
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+
+# Define the database as environment variable
+if 'SQLALCHEMY_DATABASE_URI' in os.environ:
+    SQLALCHEMY_DATABASE_URI = os.environ['SQLALCHEMY_DATABASE_URI']
+else:
+    raise Exception('Please, define the environment variable \
+        "SQLALCHEMY_DATABASE_URI".')


### PR DESCRIPTION
* Adds `config.py` missing from the initial prototype commit.  The demo
  application can be run for example like this:
  `SQLALCHEMY_DATABASE_URI='sqlite:////tmp/test.db' python ./run.py`.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>