### PR TITLE
docker: initial release of configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+*.gitignore
+
+*.pyc
+*.swp
+*.swo
+*.~
+
+.dockerignore
+Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of ClaimStore.
+# Copyright (C) 2015 CERN.
+#
+# ClaimStore is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# ClaimStore is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ClaimStore; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307,
+# USA.
+
+# Use Python-3.4:
+FROM python:3.4
+
+# Install some prerequisites ahead of `requirements.txt` in order to
+# profit from the docker build cache:
+RUN pip install flask \
+                flask-sqlalchemy \
+                jsonschema \
+                pep257 \
+                psycopg2 \
+                pytest \
+                pytest-cov \
+                pytest-pep8 \
+                sphinx
+
+# Install all prerequisites:
+ADD requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+
+# Add sources to `code` and work there:
+WORKDIR /code
+ADD . /code
+
+# Run container as user `claimstore` with UID `1000`, which should match
+# current host user in most situations:
+RUN adduser --uid 1000 --disabled-password --gecos '' claimstore && \
+    chown -R claimstore:claimstore /code
+
+# Start ClaimStore application:
+USER claimstore
+CMD  ["python", "run.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of ClaimStore.
+# Copyright (C) 2015 CERN.
+#
+# ClaimStore is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# ClaimStore is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ClaimStore; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307,
+# USA.
+
+web:
+  build: .
+  command: python run.py
+  environment:
+    - SQLALCHEMY_DATABASE_URI=postgres://postgres:postgres@db:5432/postgres
+  ports:
+    - "8080:8080"
+  volumes:
+    - .:/code
+  links:
+    - db
+db:
+  image: postgres


### PR DESCRIPTION
* Initial release of Docker configuration suitable for local ClaimStore
  developments.  (closes #15)

* Usage:

    $ docker-compose build
    $ docker-compose up
    $ firefox http://127.0.0.1:8080/

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>