### PR TITLE
global: system ingestion date

### DIFF
--- a/claimstore/modules/claims/models.py
+++ b/claimstore/modules/claims/models.py
@@ -43,6 +43,11 @@ class Claim(db.Model):
         unique=True,
         default=lambda: str(uuid4())
     )
+    received = db.Column(
+        UTCDateTime,
+        default=now_utc,
+        nullable=False
+    )
     created = db.Column(
         UTCDateTime,
         nullable=False
@@ -105,7 +110,7 @@ class Claimant(db.Model):
     )
     joined = db.Column(
         UTCDateTime,
-        default=now_utc(),
+        default=now_utc,
     )
     name = db.Column(
         db.String,

--- a/claimstore/modules/claims/restful.py
+++ b/claimstore/modules/claims/restful.py
@@ -20,7 +20,7 @@
 
 """Restful resources for the claims module."""
 
-import isodate
+import isodate  # noqa
 from flask import Blueprint, jsonify, request
 
 from claimstore.app import db
@@ -162,7 +162,8 @@ def get_claim():
     """GET service that returns the stored claims."""
     return jsonify(
         json_list=[
-            {'created': c.created.isoformat(),
+            {'received': c.received.isoformat(),
+             'created': c.created.isoformat(),
              'claim_details': c.claim_details} for c in Claim.query.all()
         ]
     )


### PR DESCRIPTION
* Saves an ingestion date in the database. (closes #7)

* Exposes that ingestion date in GET queries.

Signed-off-by: Jose Benito Gonzalez Lopez <jose.benito.gonzalez@cern.ch>