### PR TITLE
api: resource predicates

### DIFF
--- a/claimstore/modules/claims/restful.py
+++ b/claimstore/modules/claims/restful.py
@@ -333,6 +333,16 @@ class IdentifierResource(ClaimStoreResource):
         return [id_type.name for id_type in id_types]
 
 
+class PredicateResource(ClaimStoreResource):
+
+    """Resource that handles Predicate requests."""
+
+    def get(self):
+        """GET service that returns the stored predicates."""
+        predicates = Predicate.query.all()
+        return [pred.name for pred in predicates]
+
+
 claims_api.add_resource(Subscription,
                         '/subscribe',
                         endpoint='subscribe')
@@ -342,3 +352,6 @@ claims_api.add_resource(ClaimsResource,
 claims_api.add_resource(IdentifierResource,
                         '/identifiers',
                         endpoint='identifiers')
+claims_api.add_resource(PredicateResource,
+                        '/predicates',
+                        endpoint='predicates')

--- a/claimstore/templates/api.html
+++ b/claimstore/templates/api.html
@@ -35,6 +35,7 @@
       <li><a class="page-scroll" href="#submitclaim">Submit claims</a></li>
       <li><a class="page-scroll" href="#listclaims">List claims</a></li>
       <li><a class="page-scroll" href="#listidentifiers">List identifiers</a></li>
+      <li><a class="page-scroll" href="#listpredicates">List predicates</a></li>
     </ul>
   </div>
   <div class="col-sm-9 col-md-9 doc-content">
@@ -379,6 +380,79 @@ print response.json()
                     <pre>
 import requests
 response = requests.get("http://localhost:8080/identifiers")
+print response.json()
+                    </pre>
+                  </div>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+    <section id="listpredicates">
+      <h3>List predicates</h3>
+      <div class="table-responsive">
+        <table class="table table-bordered table-striped">
+          <colgroup>
+            <col class="col-xs-1">
+            <col class="col-xs-7">
+          </colgroup>
+          <thead>
+            <tr>
+              <th colspan="2">GET /predicates</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">Description</th>
+              <td>List of predicates in ClaimStore</td>
+            </tr>
+            <tr>
+              <th scope="row">URL</th>
+              <td>http://localhost:8080/predicates</td>
+            </tr>
+            <tr>
+              <th scope="row">Method</th>
+              <td>GET</td>
+            </tr>
+            <tr>
+              <th scope="row">Success response</th>
+              <td>
+                <p>JSON list with all the predicates.</p>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row">Error response</th>
+              <td>
+                <ul>
+                  <li>Code: <code>40X</code></li>
+                  <li>Body: JSON with status and message</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row">Example</th>
+              <td>
+                <ul id="example-tabs-list" class="nav nav-tabs">
+                  <li role="presentation" class="active"><a href="#httpie-list-predicates" data-toogle="tab">httpie</a></li>
+                  <li role="presentation"><a href="#curl-list-predicates" data-toogle="tab">cURL</a></li>
+                  <li role="presentation"><a href="#python-list-predicates" data-toogle="tab">Python</a></li>
+                </ul>
+                <div class="tab-content">
+                  <div class="tab-pane active" id="httpie-list-predicates">
+                    <br />
+                    <pre>http GET http://localhost:8080/predicates</pre>
+                  </div>
+                  <div class="tab-pane curl" id="curl-list-predicates">
+                    <br />
+                    <pre>curl http://localhost:8080/predicates</pre>
+                  </div>
+                  <div class="tab-pane" id="python-list-predicates">
+                    <br />
+                    <pre>
+import requests
+response = requests.get("http://localhost:8080/predicates")
 print response.json()
                     </pre>
                   </div>

--- a/tests/test_restful_api.py
+++ b/tests/test_restful_api.py
@@ -267,3 +267,10 @@ class RestfulAPITestCase(ClaimStoreTestCase):
         resp = self.test_app.get('/identifiers')
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(resp.json), 7)
+
+    def test_get_predicates(self):
+        """Testing GET predicates api."""
+        self._populate_for_search()
+        resp = self.test_app.get('/predicates')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.json), 7)


### PR DESCRIPTION
* Adds a new api resources in order to list all the predicates that are
  stored in the database at the moment. (closes #32)

Signed-off-by: Jose Benito Gonzalez Lopez <jose.benito.gonzalez@cern.ch>