### PR TITLE
installation: capitalisation of pre-requisites

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ FROM python:3.4
 
 # Install some prerequisites ahead of `setup.py` in order to profit
 # from the docker build cache:
-RUN pip install flask \
-                flask-restful \
-                flask-sqlalchemy \
+RUN pip install Flask \
+                Flask-RESTful \
+                Flask-SQLAlchemy \
                 isodate \
                 jsonschema \
                 psycopg2 \

--- a/setup.py
+++ b/setup.py
@@ -92,9 +92,9 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'flask',
-        'flask-restful',
-        'flask-sqlalchemy',
+        'Flask',
+        'Flask-RESTful',
+        'Flask-SQLAlchemy',
         'isodate',
         'jsonschema',
         'psycopg2',


### PR DESCRIPTION
* Amends capitalisation of Pythonic pre-requisites, e.g. `Flask` instead
  of `flask`, in order to make `python setup.py install` working.
  Consequently, this makes the autodoc documentation building at RTFD
  working in their virtual environments.  (closes #36)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>