### PR TITLE
global: added ip-based control mechanism

### DIFF
--- a/claimstore/config.py
+++ b/claimstore/config.py
@@ -37,3 +37,11 @@ BASE_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), '..')
 # Define the database as environment variable
 if 'SQLALCHEMY_DATABASE_URI' in os.environ:
     SQLALCHEMY_DATABASE_URI = os.environ['SQLALCHEMY_DATABASE_URI']
+
+# Define the IPs that can use the RESTful API. The list of IPs should be
+# separated by whitespaces.
+if 'CLAIMSTORE_ALLOWED_IPS' in os.environ and \
+        os.environ['CLAIMSTORE_ALLOWED_IPS'].strip():
+    CLAIMSTORE_ALLOWED_IPS = os.environ['CLAIMSTORE_ALLOWED_IPS']
+else:
+    CLAIMSTORE_ALLOWED_IPS = '127.0.0.1'

--- a/tests/test_restful_api.py
+++ b/tests/test_restful_api.py
@@ -43,7 +43,10 @@ class RestfulAPITestCase(ClaimStoreTestCase):
         super(RestfulAPITestCase, self).setUp()
 
         with self.app.app_context():
-            self.test_app = TestApp(self.app)
+            self.test_app = TestApp(
+                self.app,
+                extra_environ=dict(REMOTE_ADDR='127.0.0.1')
+            )
             create_all_predicates()
 
     def _populate_all(self):


### PR DESCRIPTION
* Adds a temporary access control mechanism based on IPs. Administrators
  can create an environment variable `CLAIMSTORE_ALLOWED_IPS` and define
  the list of IPs that can access the RESTful API. Proper authentication
  and access control mechanism should be done in the near future.
  (closes #58)

Signed-off-by: Jose Benito Gonzalez Lopez <jose.benito.gonzalez@cern.ch>