### PR TITLE
tests: json files validated against schema

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+known_third_party=webtest

--- a/claimstore/core/json.py
+++ b/claimstore/core/json.py
@@ -62,29 +62,25 @@ def validate_json(json_input, schema):
     :param schema: JSON schema to use in the validation. It must be a string
                    with the format module.schema_name (e.g. claims.claimants).
     :type schema: str.
-    :returns: True if `json_input` follows the schema. False otherwise.
-    :rtype: bool.
+    :raises: :exc:`ValidationError` if the instance is invalid.
     """
-    if schema:
-        schema_content = get_json_schema(schema)
-        module_name, schema_name = schema.split('.')
-        resolver = jsonschema.RefResolver('{}/'.format(
-            pathlib.Path(
-                os.path.join(
-                    current_app.config['BASE_DIR'],
-                    'claimstore',
-                    'modules',
-                    module_name,
-                    'static',
-                    'json',
-                    'schemas'
-                )
-            ).as_uri()),
-            schema_content
-        )
-        jsonschema.Draft4Validator(
-            json.loads(schema_content),
-            resolver=resolver
-        ).validate(json_input)
-        return True
-    return False
+    schema_content = get_json_schema(schema)
+    module_name, schema_name = schema.split('.')
+    resolver = jsonschema.RefResolver('{}/'.format(
+        pathlib.Path(
+            os.path.join(
+                current_app.config['BASE_DIR'],
+                'claimstore',
+                'modules',
+                module_name,
+                'static',
+                'json',
+                'schemas'
+            )
+        ).as_uri()),
+        schema_content
+    )
+    jsonschema.Draft4Validator(
+        json.loads(schema_content),
+        resolver=resolver
+    ).validate(json_input)

--- a/claimstore/modules/claims/cli.py
+++ b/claimstore/modules/claims/cli.py
@@ -63,7 +63,7 @@ def initdb(config):
     load_all_predicates(config)
     load_all_pids(config)
     load_all_claimants(config)
-    click.echo('Database successfully initialised.')
+    click.echo('Database initialisation completed.')
 
 
 @click.command()
@@ -95,7 +95,7 @@ def populatedb(data):
                 )
     try:
         load_all_claims(config_path=data)
-        click.echo('Database successfully populated.')
+        click.echo('Database populate completed.')
     except Exception:
         click.echo(
             'Claims could not be loaded. Try `claimstore initdb` first.'

--- a/claimstore/modules/claims/fixtures/claim.py
+++ b/claimstore/modules/claims/fixtures/claim.py
@@ -55,34 +55,39 @@ def load_all_claims(test_app=None, config_path=None):
         )
     for claim_fp in glob.glob("{}/*.json".format(claims_filepath)):
         with open(claim_fp) as f:
-            test_app.post_json(
+            resp = test_app.post_json(
                 '/claims',
-                json.loads(f.read()))
+                json.load(f),
+                expect_errors=True
+            )
+            if resp.status_code != 200:
+                print('{} could not be loaded. {}.'.format(
+                    claim_fp,
+                    resp.json['message']
+                ))
 
 
 @pytest.fixture
 def dummy_claim():
     """Fixture that creates a dummy claim."""
-    return json.loads("""
-        {
-          "claimant": "dummy_claimant",
-          "subject": {
+    return {
+        "claimant": "dummy_claimant",
+        "subject": {
             "type": "CDS_RECORD_ID",
             "value": "2001192"
-          },
-          "predicate": "is_same_as",
-          "certainty": 1.0,
-          "object": {
+        },
+        "predicate": "is_same_as",
+        "certainty": 1.0,
+        "object": {
             "type": "CDS_REPORT_NUMBER",
             "value": "CMS-PAS-HIG-14-008"
-          },
-          "arguments": {
+        },
+        "arguments": {
             "human": 0,
             "actor": "CDS_submission"
-          },
-          "created": "2015-03-25T11:00:00Z"
-        }
-        """)
+        },
+        "created": "2015-03-25T11:00:00Z"
+    }
 
 
 def _remove_all_claims():

--- a/claimstore/modules/claims/restful.py
+++ b/claimstore/modules/claims/restful.py
@@ -28,6 +28,7 @@ from functools import wraps
 import isodate  # noqa
 from flask import Blueprint, current_app, request
 from flask_restful import Api, Resource, abort, inputs, reqparse
+from jsonschema import ValidationError
 from sqlalchemy import or_
 
 from claimstore.core.datetime import loc_date_utc
@@ -100,11 +101,11 @@ class ClaimStoreResource(Resource):
         """Validate that json_data follows the appropiate JSON schema.
 
         :param json_data: JSON data to be validated.
-        :raises: InvalidJSONData
+        :raises: :exc:`InvalidJSONData` if the instance is invalid.
         """
         try:
             validate_json(json_data, self.json_schema)
-        except Exception as e:
+        except ValidationError as e:
             raise InvalidJSONData('JSON data is not valid', extra=str(e))
 
 


### PR DESCRIPTION
* Validates the JSON files used for configuration (`claimstore initdb`)
  and populating (`claimstore populatedb`). (closes #64)

Signed-off-by: Jose Benito Gonzalez Lopez <jose.benito.gonzalez@cern.ch>