### PR TITLE
api: add transitive search

### DIFF
--- a/claimstore/ext/sqlalchemy.py
+++ b/claimstore/ext/sqlalchemy.py
@@ -37,16 +37,12 @@ models = RegistryProxy(
 def setup_app(app):
     """Setup sqlalchemy."""
     # Add extension CLI to application.
-    app.cli.add_command(dropalldb)
+    app.cli.add_command(database)
     db.init_app(app)
 
 
-@click.command()
+@click.group()
 @with_appcontext
-def dropalldb():
-    """Drop database."""
-    if click.confirm('Are you sure you want to drop the whole database?'):
-        db.drop_all()
-        click.echo('Database dropped')
-    else:
-        click.echo('Command aborted')
+def database():
+    """Database related commands."""
+    pass

--- a/claimstore/modules/claims/config.py
+++ b/claimstore/modules/claims/config.py
@@ -18,16 +18,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307,
 # USA.
 
-web:
-  build: .
-  command: bash -c "claimstore database create && claimstore database populate && python run.py"
-  environment:
-    - SQLALCHEMY_DATABASE_URI=postgres://postgres:postgres@db:5432/postgres
-  ports:
-    - "5000:5000"
-  volumes:
-    - .:/code
-  links:
-    - db
-db:
-  image: postgres
+"""Module configuration."""
+
+CFG_EQUIVALENT_PREDICATES = ['is_same_as', 'is_variant_of']

--- a/claimstore/modules/claims/fixtures/claim.py
+++ b/claimstore/modules/claims/fixtures/claim.py
@@ -68,20 +68,32 @@ def load_all_claims(test_app=None, config_path=None):
 
 
 @pytest.fixture
-def dummy_claim():
+def dummy_subject():
+    """Fixture of a dummy subject."""
+    return {
+        "type": "CDS_RECORD_ID",
+        "value": "test-2001192"
+    }
+
+
+@pytest.fixture
+def dummy_object():
+    """Fixture of a dummy object."""
+    return {
+        "type": "CDS_REPORT_NUMBER",
+        "value": "CMS-PAS-HIG-14-008"
+    }
+
+
+@pytest.fixture
+def dummy_claim(dummy_subject, dummy_object):
     """Fixture that creates a dummy claim."""
     return {
         "claimant": "dummy_claimant",
-        "subject": {
-            "type": "CDS_RECORD_ID",
-            "value": "2001192"
-        },
+        "subject": dummy_subject,
         "predicate": "is_same_as",
         "certainty": 1.0,
-        "object": {
-            "type": "CDS_REPORT_NUMBER",
-            "value": "CMS-PAS-HIG-14-008"
-        },
+        "object": dummy_object,
         "arguments": {
             "human": 0,
             "actor": "CDS_submission"

--- a/claimstore/modules/claims/fixtures/claimant.py
+++ b/claimstore/modules/claims/fixtures/claimant.py
@@ -96,6 +96,15 @@ def dummy_claimant():
 
 
 @pytest.fixture
+def create_dummy_claimant(webtest_app, dummy_claimant):
+    """Add dummy claimant to the database."""
+    webtest_app.post_json(
+        '/subscribe',
+        dummy_claimant
+    )
+
+
+@pytest.fixture
 def all_claimants(db):
     """Fixture that loads all claimants."""
     load_all_claimants()

--- a/claimstore/modules/claims/templates/claims/api.html
+++ b/claimstore/modules/claims/templates/claims/api.html
@@ -36,6 +36,7 @@
       <li><a class="page-scroll" href="#listclaims">List claims</a></li>
       <li><a class="page-scroll" href="#listidentifiers">List identifiers</a></li>
       <li><a class="page-scroll" href="#listpredicates">List predicates</a></li>
+      <li><a class="page-scroll" href="#listeqids">List predicates</a></li>
     </ul>
   </div>
   <div class="col-sm-9 col-md-9 doc-content">
@@ -261,6 +262,7 @@ r = requests.post(url, data=data, headers=headers)</pre>
                   <li>role: actor's role (one can use %).</li>
                   <li>type: identifier type (e.g. DOI).</li>
                   <li>value: identifier value (e.g. 20110301).</li>
+                  <li>recurse: used in combination with "type" and "value" will find all the equivalent identifiers to the specified one.</li>
                   <li>subject: identifier type used as a subject type.</li>
                   <li>object: identifier type used as an object type.</li>
                 </ul>
@@ -453,6 +455,79 @@ print response.json()
                     <pre>
 import requests
 response = requests.get("http://localhost:5000/predicates")
+print response.json()
+                    </pre>
+                  </div>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+    <section id="listeqids">
+      <h3>List equivalent identifiers</h3>
+      <div class="table-responsive">
+        <table class="table table-bordered table-striped">
+          <colgroup>
+            <col class="col-xs-1">
+            <col class="col-xs-7">
+          </colgroup>
+          <thead>
+            <tr>
+              <th colspan="2">GET /eqids</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">Description</th>
+              <td>List of equivalent identifiers in ClaimStore</td>
+            </tr>
+            <tr>
+              <th scope="row">URL</th>
+              <td><a href="{{ url_for('claims_restful.eqids') }}">http://localhost:5000/eqids</a></td>
+            </tr>
+            <tr>
+              <th scope="row">Method</th>
+              <td>GET</td>
+            </tr>
+            <tr>
+              <th scope="row">Success response</th>
+              <td>
+                <p>JSON list with all the equivalent identifiers.</p>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row">Error response</th>
+              <td>
+                <ul>
+                  <li>Code: <code>40X</code></li>
+                  <li>Body: JSON with status and message</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row">Example</th>
+              <td>
+                <ul id="example-tabs-list" class="nav nav-tabs">
+                  <li role="presentation" class="active"><a href="#httpie-list-eqids" data-toogle="tab">httpie</a></li>
+                  <li role="presentation"><a href="#curl-list-eqids" data-toogle="tab">cURL</a></li>
+                  <li role="presentation"><a href="#python-list-eqids" data-toogle="tab">Python</a></li>
+                </ul>
+                <div class="tab-content">
+                  <div class="tab-pane active" id="httpie-list-eqids">
+                    <br />
+                    <pre>http GET http://localhost:5000/eqids</pre>
+                  </div>
+                  <div class="tab-pane curl" id="curl-list-eqids">
+                    <br />
+                    <pre>curl http://localhost:5000/eqids</pre>
+                  </div>
+                  <div class="tab-pane" id="python-list-eqids">
+                    <br />
+                    <pre>
+import requests
+response = requests.get("http://localhost:5000/eqids")
 print response.json()
                     </pre>
                   </div>

--- a/tests/myclaimstore/data/claims/claim.cds.1.json
+++ b/tests/myclaimstore/data/claims/claim.cds.1.json
@@ -2,7 +2,7 @@
   "claimant": "CDS",
   "subject": {
     "type": "CDS_RECORD_ID",
-    "value": "2001192"
+    "value": "2003192"
   },
   "predicate": "is_same_as",
   "certainty": 1.0,

--- a/tests/test_eq_ids.py
+++ b/tests/test_eq_ids.py
@@ -1,0 +1,241 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of ClaimStore.
+# Copyright (C) 2015 CERN.
+#
+# ClaimStore is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# ClaimStore is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with ClaimStore; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307,
+# USA.
+
+"""Tests for equivalent identifiers logic."""
+
+from copy import deepcopy
+
+import pytest
+from sqlalchemy.orm.exc import NoResultFound
+
+from claimstore.modules.claims.models import EquivalentIdentifier, \
+    IdentifierType
+
+pytest_plugins = (
+    'claimstore.modules.claims.fixtures.claim',
+    'claimstore.modules.claims.fixtures.claimant',
+    'claimstore.modules.claims.fixtures.pid',
+    'claimstore.modules.claims.fixtures.predicate'
+)
+
+
+def populate_all(f):
+    """Simple decorator to populate db."""
+    return pytest.mark.usefixtures(
+        'all_predicates',
+        'all_pids',
+        'all_claimants',
+        'all_claims',
+        'create_dummy_claimant'
+    )(f)
+
+
+@populate_all
+def test_new_equivalence(webtest_app, dummy_claim, dummy_subject,
+                         dummy_object):
+    """New subject and object.
+
+    Test when the subject and object are not in the equivalent_identifier
+    table yet.
+    """
+    dummy_subject['value'] = 'xxx'
+    dummy_object['value'] = 'yyy'
+
+    pre_all_eqs = EquivalentIdentifier.query.all()
+
+    ds_id = IdentifierType.query.filter_by(
+        name=dummy_subject['type']
+    ).one().id
+    do_id = IdentifierType.query.filter_by(
+        name=dummy_object['type']
+    ).one().id
+
+    # The subject and object types/values do not exist yet:
+    with pytest.raises(NoResultFound) as excinfo:
+        EquivalentIdentifier.query.filter_by(
+            type_id=ds_id,
+            value=dummy_subject['value']
+        ).one()
+        assert 'No row was found for one' in str(excinfo)
+        EquivalentIdentifier.query.filter_by(
+            type_id=do_id,
+            value=dummy_object['value']
+        ).one()
+        assert 'No row was found for one' in str(excinfo)
+
+    webtest_app.post_json(
+        '/claims',
+        dummy_claim
+    )
+
+    post_all_eqs = EquivalentIdentifier.query.all()
+    assert len(pre_all_eqs) + 2 == len(post_all_eqs)
+
+    post_dummy_subject = EquivalentIdentifier.query.filter_by(
+        type_id=ds_id,
+        value=dummy_subject['value']
+    ).one()
+
+    eqs = EquivalentIdentifier.query.filter_by(
+        eqid=post_dummy_subject.eqid
+    ).all()
+    assert len(eqs) == 2
+
+
+@populate_all
+def test_new_subject(webtest_app, dummy_claim, dummy_subject, dummy_object):
+    """Test equivalence with a new subject.
+
+    In this case, there is a new claim that will add one extra entry (the
+    subject) in the equivalent_identifier table. But the object already exists
+    so its eqid will be reused.
+    """
+    pre_all_eqs = EquivalentIdentifier.query.all()
+
+    # Get 'object' before posting new claim
+    do_id = IdentifierType.query.filter_by(
+        name=dummy_object['type']
+    ).one().id
+    pre_dummy_object = EquivalentIdentifier.query.filter_by(
+        type_id=do_id,
+        value=dummy_object['value']
+    ).one()
+
+    # Posting new claim
+    webtest_app.post_json(
+        '/claims',
+        dummy_claim
+    )
+
+    post_all_eqs = EquivalentIdentifier.query.all()
+
+    # Get 'subject' after posting new claim
+    ds_id = IdentifierType.query.filter_by(
+        name=dummy_subject['type']
+    ).one().id
+    post_dummy_subject = EquivalentIdentifier.query.filter_by(
+        type_id=ds_id,
+        value=dummy_subject['value']
+    ).one()
+
+    assert len(pre_all_eqs) + 1 == len(post_all_eqs)
+    assert pre_dummy_object.eqid == post_dummy_subject.eqid
+
+
+@populate_all
+def test_new_object(webtest_app, dummy_claim, dummy_subject, dummy_object):
+    """Test equivalence with a new object.
+
+    In this case, there is a new claim that will add one extra entry (the
+    object) in the equivalent_identifier table. But the subject already exists
+    so its eqid will be reused.
+    """
+    temp = deepcopy(dummy_object)
+    dummy_object.update(dummy_subject)
+    dummy_subject.update(temp)
+    pre_all_eqs = EquivalentIdentifier.query.all()
+
+    # Get 'subject' before posting new claim
+    ds_id = IdentifierType.query.filter_by(
+        name=dummy_subject['type']
+    ).one().id
+    pre_dummy_subject = EquivalentIdentifier.query.filter_by(
+        type_id=ds_id,
+        value=dummy_subject['value']
+    ).one()
+
+    # Posting new claim
+    webtest_app.post_json(
+        '/claims',
+        dummy_claim
+    )
+
+    post_all_eqs = EquivalentIdentifier.query.all()
+
+    # Get 'object' after posting new claim
+    do_id = IdentifierType.query.filter_by(
+        name=dummy_object['type']
+    ).one().id
+    post_dummy_object = EquivalentIdentifier.query.filter_by(
+        type_id=do_id,
+        value=dummy_object['value']
+    ).one()
+
+    assert len(pre_all_eqs) + 1 == len(post_all_eqs)
+    assert pre_dummy_subject.eqid == post_dummy_object.eqid
+
+
+@populate_all
+def test_existing_subject_object(webtest_app, dummy_claim, dummy_subject,
+                                 dummy_object):
+    """Test equivalence with an already existing subject and object.
+
+    In this case, the subject and object already exist but the have different
+    eqid. All the eqids of one set should be udpated.
+    """
+    sub_value = 'xxx'
+    ob_value = 'yyy'
+    sub_id = IdentifierType.query.filter_by(
+        name=dummy_subject['type']
+    ).one().id
+
+    # Claim with a totally new equivalence
+    dummy_subject['value'] = sub_value
+    dummy_object['value'] = ob_value
+    webtest_app.post_json(
+        '/claims',
+        dummy_claim
+    )
+    sub_eq = EquivalentIdentifier.query.filter_by(
+        type_id=sub_id,
+        value=sub_value
+    ).one()
+    assert EquivalentIdentifier.query.filter_by(eqid=sub_eq.eqid).count() == 2
+
+    # Build claim with previous subject and random existing object
+    random_eq = EquivalentIdentifier.query.filter(
+        EquivalentIdentifier.type_id != sub_id
+    ).first()
+    random_eqid = random_eq.eqid
+    dummy_object.update({
+        'type': random_eq.type.name,
+        'value': random_eq.value
+    })
+    pre_random_equivalents_count = EquivalentIdentifier.query.filter_by(
+        eqid=random_eq.eqid
+    ).count()
+    assert pre_random_equivalents_count > 0
+    assert random_eq.eqid != sub_eq.eqid
+
+    webtest_app.post_json(
+        '/claims',
+        dummy_claim
+    )
+    # After the previous claim submission, all the eqids equivalent to the
+    # object must have changed:
+    new_random_equivalents_count = EquivalentIdentifier.query.filter_by(
+        eqid=random_eqid
+    ).count()
+    sub_equivalents_count = EquivalentIdentifier.query.filter_by(
+        eqid=sub_eq.eqid
+    ).count()
+
+    assert new_random_equivalents_count == 0
+    assert sub_equivalents_count == pre_random_equivalents_count + 2

--- a/tests/test_restful_api.py
+++ b/tests/test_restful_api.py
@@ -166,12 +166,25 @@ def test_get_claims_by_type_value(webtest_app):
     # There are 2 CDS_RECORD_ID, one as subject and one as an object.
     resp = webtest_app.get('/claims?type=CDS_RECORD_ID')
     assert len(resp.json) == 2
-    # The type with value `2001192` can be found 1 times.
-    resp = webtest_app.get('/claims?value=2001192')
-    assert len(resp.json) == 1
+    # The type with value `2003192` can be found 2 times.
+    resp = webtest_app.get('/claims?value=2003192')
+    assert len(resp.json) == 2
     # Filter by type and value
-    resp = webtest_app.get('/claims?type=CDS_RECORD_ID&value=2001192')
+    resp = webtest_app.get('/claims?type=CDS_RECORD_ID&value=2003192')
+    assert len(resp.json) == 2
+
+
+@populate_all
+def test_get_claims_by_type_value_recursive(webtest_app):
+    """Testing GET claims filtering by type."""
+    resp = webtest_app.get(
+        '/claims?type=INSPIRE_RECORD_ID&value=cond-mat/9906097'
+    )
     assert len(resp.json) == 1
+    resp = webtest_app.get(
+        '/claims?type=INSPIRE_RECORD_ID&value=cond-mat/9906097&recurse=1'
+    )
+    assert len(resp.json) == 2
 
 
 @populate_all


### PR DESCRIPTION
* Adds an extra Model that keeps track of all the equivalent IDs.
  (closes #49)

* Enables transitive queries to fetch all the related claims (through
  `/claims?type=xxx&value=yyy&recurse=1`.

* Adds a new API resource `/eqids` to list all the equivalent IDs (one can also
  filter by a specific id using the argument `eqid=`).

Signed-off-by: Jose Benito Gonzalez Lopez <jose.benito.gonzalez@cern.ch>