### PR TITLE
global: finer allowed ip configuration

### DIFF
--- a/claimstore/config.py
+++ b/claimstore/config.py
@@ -38,10 +38,10 @@ BASE_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), '..')
 if 'SQLALCHEMY_DATABASE_URI' in os.environ:
     SQLALCHEMY_DATABASE_URI = os.environ['SQLALCHEMY_DATABASE_URI']
 
-# Define the IPs that can use the RESTful API. The list of IPs should be
-# separated by whitespaces.
+# Define the IP networks (e.g. 146.16.0.0/16) that can use the RESTful API.
+# The list of IP networks should be separated by whitespaces.
 if 'CLAIMSTORE_ALLOWED_IPS' in os.environ and \
         os.environ['CLAIMSTORE_ALLOWED_IPS'].strip():
-    CLAIMSTORE_ALLOWED_IPS = os.environ['CLAIMSTORE_ALLOWED_IPS']
+    CLAIMSTORE_ALLOWED_IPS = os.environ['CLAIMSTORE_ALLOWED_IPS'].split(' ')
 else:
-    CLAIMSTORE_ALLOWED_IPS = '127.0.0.1'
+    CLAIMSTORE_ALLOWED_IPS = ['127.0.0.1/32']

--- a/claimstore/modules/claims/restful.py
+++ b/claimstore/modules/claims/restful.py
@@ -25,6 +25,7 @@ isort:skip_file
 
 from collections import defaultdict
 from functools import wraps
+from ipaddress import ip_address, ip_network
 
 import isodate  # noqa
 from flask import Blueprint, current_app, request
@@ -77,7 +78,11 @@ def check_ip(f):
     """
     @wraps(f)
     def inner(*args, **kwargs):
-        if request.remote_addr in current_app.config['CLAIMSTORE_ALLOWED_IPS']:
+        if any(
+                [ip_address(request.remote_addr) in ip_network(ip_net)
+                 for ip_net
+                 in current_app.config['CLAIMSTORE_ALLOWED_IPS']]
+        ):
             return f(*args, **kwargs)
         else:
             abort(


### PR DESCRIPTION
* Improves the IP access control by adding the possibility to add IP
  networks (e.g. 146.16.0.0/16) in the env variable
  CLAIMSTORE_ALLOWED_IPS. (closes #77)

Signed-off-by: Jose Benito Gonzalez Lopez <jose.benito.gonzalez@cern.ch>