### PR TITLE
docker: production-ready compose configuration

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -19,24 +19,42 @@
 # USA.
 
 web:
+  restart: "always"
   build: .
   command: python run.py
   environment:
     - SQLALCHEMY_DATABASE_URI=postgres://postgres:postgres@db:5432/postgres
-    - CLAIMSTORE_DEBUG=True
+    - CLAIMSTORE_DEBUG=False
   ports:
     - "5000:5000"
-  volumes:
-    - .:/code
+  volumes_from:
+    - static
   links:
     - db
+nginx:
+  restart: "always"
+  build: ./nginx
+  ports:
+    - "80:80"
+  volumes_from:
+    - static
+    - web
+  links:
+    - web
+static:
+  restart: "no"
+  build: .
+  volumes:
+    - /code/claimstore/static
+  user: claimstore
 db:
+  restart: "always"
   image: postgres
   volumes_from:
     - data
 data:
+  restart: "no"
   image: postgres
   command: /bin/true
-  restart: "no"
   volumes:
     - /var/lib/postgresql

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -18,25 +18,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307,
 # USA.
 
-web:
-  build: .
-  command: python run.py
-  environment:
-    - SQLALCHEMY_DATABASE_URI=postgres://postgres:postgres@db:5432/postgres
-    - CLAIMSTORE_DEBUG=True
-  ports:
-    - "5000:5000"
-  volumes:
-    - .:/code
-  links:
-    - db
-db:
-  image: postgres
-  volumes_from:
-    - data
-data:
-  image: postgres
-  command: /bin/true
-  restart: "no"
-  volumes:
-    - /var/lib/postgresql
+FROM nginx
+RUN rm /etc/nginx/conf.d/default.conf
+ADD claimstore.conf /etc/nginx/conf.d/

--- a/nginx/claimstore.conf
+++ b/nginx/claimstore.conf
@@ -1,0 +1,23 @@
+server {
+
+    listen 80;
+    server_name localhost;
+    charset utf-8;
+
+    location /static {
+        root /code/claimstore;
+    }
+
+    location / {
+        proxy_pass http://web:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+}


### PR DESCRIPTION
* Adds production-ready docker-compose configuration (1) without local
  volume mounting, (2) without debugging, (3) with nginx front-end
  server, (4) with different port binding, (5) with restart policy,
  (6) with static data volume and (7) with DB data volume. Suitable for
  use on remote VMs via `docker-machine`.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>