### PR TITLE
tests: block tests if many claims in database

### DIFF
--- a/claimstore/testing/fixtures/claim.py
+++ b/claimstore/testing/fixtures/claim.py
@@ -114,5 +114,12 @@ def _remove_all_claims():
 @pytest.fixture
 def all_claims(db):
     """Fixture that loads all claims."""
+    # if there are more than 10 claims in the database, it is assumed that it
+    # is running in a production-like environment
+    claims = Claim.query.paginate(1, 10, False)
+    if claims.total > 10:
+        raise Exception('It seems that you are running tests in a '
+                        'production-like environment. Tests run only on '
+                        'databases with 10 or less claims stored.')
     _remove_all_claims()
     load_all_claims()


### PR DESCRIPTION
* Prevents from running tests in databases that store more than 10
  claims (assumed as production-like databases). (closes #63)

Signed-off-by: Jose Benito Gonzalez Lopez <jose.benito.gonzalez@cern.ch>