### PR TITLE
global: intruduced new claimants and ids

### DIFF
--- a/tests/myclaimstore/config/claimants/ads.json
+++ b/tests/myclaimstore/config/claimants/ads.json
@@ -1,0 +1,4 @@
+{
+  "name": "ADS",
+  "url": "http://adsabs.harvard.edu/"
+}

--- a/tests/myclaimstore/config/claimants/arxiv.json
+++ b/tests/myclaimstore/config/claimants/arxiv.json
@@ -1,0 +1,4 @@
+{
+  "name": "ARXIV",
+  "url": "http://arxiv.org/"
+}

--- a/tests/myclaimstore/config/pids/ads-bibcode.json
+++ b/tests/myclaimstore/config/pids/ads-bibcode.json
@@ -1,0 +1,7 @@
+{
+  "type": "ADS_BIBCODE",
+  "description": "ADS bibcode",
+  "url": "http://adsabs.harvard.edu/abs/<ADS_BIBCODE>",
+  "example_value": "2002ApJ...578...90F",
+  "example_url": "http://adsabs.harvard.edu/abs/2002ApJ...578...90F"
+}

--- a/tests/myclaimstore/config/pids/orcid.json
+++ b/tests/myclaimstore/config/pids/orcid.json
@@ -1,0 +1,7 @@
+{
+  "type": "ORCID",
+  "description": "ORCID persistent digital identifier",
+  "url": "http://orcid.org/<ORCID>",
+  "example_value": "0000-0001-8248-603X",
+  "example_url": "http://orcid.org/0000-0001-8248-603X"
+}


### PR DESCRIPTION
* Introduces ARXIV claimant, ADS claimant, ADS_BIBCODE id, and ORCID id.
  (closes #96)

Signed-off-by: Jose Benito Gonzalez Lopez <jose.benito.gonzalez@cern.ch>