### PR TITLE
101 api claimants

### DIFF
--- a/claimstore/restful.py
+++ b/claimstore/restful.py
@@ -127,7 +127,7 @@ class ClaimantResource(ClaimStoreResource):
     def post(self):
         """Register a new claimant in the ClaimStore.
 
-        .. http:post:: /subscribe
+        .. http:post:: /api/subscribe
 
             This resource is expecting JSON data with all the necessary
             information of a new claimant.
@@ -136,7 +136,7 @@ class ClaimantResource(ClaimStoreResource):
 
             .. sourcecode:: http
 
-                POST /subscribe HTTP/1.1
+                POST /api/subscribe HTTP/1.1
                 Content-Type: application/json
                 Host: localhost:5000
 
@@ -305,7 +305,7 @@ class ClaimResource(ClaimStoreResource, RestfulSQLAlchemyPaginationMixIn):
     def post(self):
         """Record a new claim.
 
-        .. http:post:: /claims
+        .. http:post:: /api/claims
 
             This resource is expecting JSON data with all the necessary
             information of a new claim.
@@ -314,7 +314,7 @@ class ClaimResource(ClaimStoreResource, RestfulSQLAlchemyPaginationMixIn):
 
             .. sourcecode:: http
 
-                POST /claims HTTP/1.1
+                POST /api/claims HTTP/1.1
                 Accept: application/json
                 Content-Length: 336
                 Content-Type: application/json
@@ -453,7 +453,7 @@ class ClaimResource(ClaimStoreResource, RestfulSQLAlchemyPaginationMixIn):
     def get(self):
         """GET service that returns the stored claims.
 
-        .. http:get:: /claims
+        .. http:get:: /api/claims
 
             Returns a JSON list with all the claims matching the query
             parameters.
@@ -462,7 +462,7 @@ class ClaimResource(ClaimStoreResource, RestfulSQLAlchemyPaginationMixIn):
 
                 .. sourcecode:: http
 
-                    GET /claims?type=INSPIRE_RECORD_ID&value=cond-mat/9906097&
+                    GET /api/claims?type=CDS_RECORD_ID&value=cond-mat/9906097&
                     recurse=1 HTTP/1.1
                     Accept: */*
                     Host: localhost:5000
@@ -680,7 +680,7 @@ class IdentifierResource(ClaimStoreResource):
     def get(self):
         """GET service that returns the stored identifiers.
 
-        .. http:get:: /identifiers
+        .. http:get:: /api/identifiers
 
             Returns a JSON list with all the available identifiers.
 
@@ -688,7 +688,7 @@ class IdentifierResource(ClaimStoreResource):
 
                 .. sourcecode:: http
 
-                    GET /identifiers HTTP/1.1
+                    GET /api/identifiers HTTP/1.1
                     Accept: */*
                     Host: localhost:5000
 
@@ -730,7 +730,7 @@ class PredicateResource(ClaimStoreResource):
     def get(self):
         """GET service that returns all the available predicates.
 
-        .. http:get:: /predicates
+        .. http:get:: /api/predicates
 
             Returns a JSON list with all the predicates.
 
@@ -738,7 +738,7 @@ class PredicateResource(ClaimStoreResource):
 
                 .. sourcecode:: http
 
-                    GET /predicates HTTP/1.1
+                    GET /api/predicates HTTP/1.1
                     Accept: */*
                     Host: localhost:5000
 
@@ -778,7 +778,7 @@ class EquivalentIdResource(ClaimStoreResource):
     def get(self, eqid=None):
         """GET service that returns all the stored Equivalent Identifiers.
 
-        .. http:get:: /eqids/(uuid:eqid)
+        .. http:get:: /api/eqids/(uuid:eqid)
 
             Returns all the type/value entries in the index grouped by their
             equivalent identifiers.
@@ -787,13 +787,13 @@ class EquivalentIdResource(ClaimStoreResource):
 
                 .. sourcecode:: http
 
-                    GET /eqids HTTP/1.1
+                    GET /api/eqids HTTP/1.1
                     Accept: */*
                     Host: localhost:5000
 
                 .. sourcecode:: http
 
-                    GET /eqids/0e64606e-68ce-482e-ad59-1e9981394f84 HTTP/1.1
+                    GET /api/eqids/0e64606e-68ce-482e-ad59-1e9981394f8 HTTP/1.1
                     Accept: */*
                     Host: localhost:5000
 
@@ -857,18 +857,18 @@ class EquivalentIdResource(ClaimStoreResource):
 
 
 claims_api.add_resource(ClaimantResource,
-                        '/subscribe',
+                        '/api/subscribe',
                         endpoint='subscribe')
 claims_api.add_resource(ClaimResource,
-                        '/claims',
+                        '/api/claims',
                         endpoint='claims')
 claims_api.add_resource(IdentifierResource,
-                        '/identifiers',
+                        '/api/identifiers',
                         endpoint='identifiers')
 claims_api.add_resource(PredicateResource,
-                        '/predicates',
+                        '/api/predicates',
                         endpoint='predicates')
 claims_api.add_resource(EquivalentIdResource,
-                        '/eqids',
-                        '/eqids/<uuid:eqid>',
+                        '/api/eqids',
+                        '/api/eqids/<uuid:eqid>',
                         endpoint='eqids')

--- a/claimstore/templates/subscription.html
+++ b/claimstore/templates/subscription.html
@@ -52,7 +52,7 @@
       if(!errors.length) {
         $.ajax({
           type: 'POST',
-          url: '{{ url_for("claims_restful.subscribe") }}',
+          url: '{{ url_for("claims_restful.claimants") }}',
           data: JSON.stringify(editor.getValue()),
           contentType: "application/json; charset=utf-8",
           dataType: "json",

--- a/claimstore/testing/fixtures/claim.py
+++ b/claimstore/testing/fixtures/claim.py
@@ -56,7 +56,7 @@ def load_all_claims(test_app=None, config_path=None):
     for claim_fp in glob.glob("{}/*.json".format(claims_filepath)):
         with open(claim_fp) as f:
             resp = test_app.post_json(
-                '/claims',
+                '/api/claims',
                 json.load(f),
                 expect_errors=True
             )

--- a/claimstore/testing/fixtures/claimant.py
+++ b/claimstore/testing/fixtures/claimant.py
@@ -99,7 +99,7 @@ def dummy_claimant():
 def create_dummy_claimant(webtest_app, dummy_claimant):
     """Add dummy claimant to the database."""
     webtest_app.post_json(
-        '/api/subscribe',
+        '/api/claimants',
         dummy_claimant
     )
 

--- a/claimstore/testing/fixtures/claimant.py
+++ b/claimstore/testing/fixtures/claimant.py
@@ -99,7 +99,7 @@ def dummy_claimant():
 def create_dummy_claimant(webtest_app, dummy_claimant):
     """Add dummy claimant to the database."""
     webtest_app.post_json(
-        '/subscribe',
+        '/api/subscribe',
         dummy_claimant
     )
 

--- a/docs/users.rst
+++ b/docs/users.rst
@@ -3,8 +3,8 @@ Restful Resources
 -----------------
 
 
-Subscribe to ClaimStore
-=======================
+Submit a claimant
+=================
 
 .. autosimple:: claimstore.restful.ClaimantResource.post
 
@@ -17,7 +17,7 @@ Subscribe to ClaimStore
         import json
         import requests
 
-        url = "http://localhost:5000/api/subscribe/
+        url = "http://localhost:5000/api/claimants/
         headers = {"Content-Type": "application/json"}
         with open(
             '$PROJECT_HOME/tests/config/claimants/cds.json'
@@ -29,16 +29,43 @@ Subscribe to ClaimStore
 
     .. sourcecode:: console
 
-        $ http POST http://localhost:5000/api/subscribe < tests/myclaimstore/config/claimants/cds.json
+        $ http POST http://localhost:5000/api/claimants < tests/myclaimstore/config/claimants/cds.json
 
 * From `curl <http://curl.haxx.se/>`_:
 
     .. sourcecode:: console
 
-        $ curl http://localhost:5000/api/subscribe \
+        $ curl http://localhost:5000/api/claimants \
                -H "Content-Type: application/json" \
                -d @tests/myclaimstore/config/claimants/inspire.json -X POST -v
 
+
+List claimants
+==============
+
+.. autosimple:: claimstore.restful.ClaimantResource.get
+
+**Usage**:
+
+* From `python <https://www.python.org/>`_:
+
+    .. sourcecode:: python
+
+        import requests
+        response = requests.get("http://localhost:5000/api/claimants")
+        print response.json()
+
+* From `httpie <https://github.com/jkbrzt/httpie>`_:
+
+    .. sourcecode:: console
+
+        $ http GET http://localhost:5000/api/claimants
+
+* From `curl <http://curl.haxx.se/>`_:
+
+    .. sourcecode:: console
+
+        $ curl http://localhost:5000/api/claimants
 
 
 Submit a claim

--- a/docs/users.rst
+++ b/docs/users.rst
@@ -17,7 +17,7 @@ Subscribe to ClaimStore
         import json
         import requests
 
-        url = "http://localhost:5000/subscribe/
+        url = "http://localhost:5000/api/subscribe/
         headers = {"Content-Type": "application/json"}
         with open(
             '$PROJECT_HOME/tests/config/claimants/cds.json'
@@ -29,13 +29,13 @@ Subscribe to ClaimStore
 
     .. sourcecode:: console
 
-        $ http POST http://localhost:5000/subscribe < tests/myclaimstore/config/claimants/cds.json
+        $ http POST http://localhost:5000/api/subscribe < tests/myclaimstore/config/claimants/cds.json
 
 * From `curl <http://curl.haxx.se/>`_:
 
     .. sourcecode:: console
 
-        $ curl http://localhost:5000/subscribe \
+        $ curl http://localhost:5000/api/subscribe \
                -H "Content-Type: application/json" \
                -d @tests/myclaimstore/config/claimants/inspire.json -X POST -v
 
@@ -55,7 +55,7 @@ Submit a claim
         import json
         import requests
 
-        url = "http://localhost:5000/claims/
+        url = "http://localhost:5000/api/claims/
         headers = {"Content-Type": "application/json"}
         with open(
             '$PROJECT_HOME/tests/config/claims/cds.1.json'
@@ -67,13 +67,13 @@ Submit a claim
 
     .. sourcecode:: console
 
-        $ http POST http://localhost:5000/claims < tests/myclaimstore/data/claims/cds.1.json
+        $ http POST http://localhost:5000/api/claims < tests/myclaimstore/data/claims/cds.1.json
 
 * From `curl <http://curl.haxx.se/>`_:
 
     .. sourcecode:: console
 
-        $ curl http://localhost:5000/claims \
+        $ curl http://localhost:5000/api/claims \
                -H "Content-Type: application/json" \
                -d @tests/myclaimstore/data/claims/inspire.1.json -X POST -v
 
@@ -90,20 +90,20 @@ List claims
     .. sourcecode:: python
 
         import requests
-        response = requests.get("http://localhost:5000/claims")
+        response = requests.get("http://localhost:5000/api/claims")
         print response.json()
 
 * From `httpie <https://github.com/jkbrzt/httpie>`_:
 
     .. sourcecode:: console
 
-        $ http GET http://localhost:5000/claims
+        $ http GET http://localhost:5000/api/claims
 
 * From `curl <http://curl.haxx.se/>`_:
 
     .. sourcecode:: console
 
-        $ curl http://localhost:5000/claims
+        $ curl http://localhost:5000/api/claims
 
 
 List identifiers
@@ -118,20 +118,20 @@ List identifiers
     .. sourcecode:: python
 
         import requests
-        response = requests.get("http://localhost:5000/identifiers")
+        response = requests.get("http://localhost:5000/api/identifiers")
         print response.json()
 
 * From `httpie <https://github.com/jkbrzt/httpie>`_:
 
     .. sourcecode:: console
 
-        $ http GET http://localhost:5000/identifiers
+        $ http GET http://localhost:5000/api/identifiers
 
 * From `curl <http://curl.haxx.se/>`_:
 
     .. sourcecode:: console
 
-        $ curl http://localhost:5000/identifiers
+        $ curl http://localhost:5000/api/identifiers
 
 
 List predicates
@@ -146,20 +146,20 @@ List predicates
     .. sourcecode:: python
 
         import requests
-        response = requests.get("http://localhost:5000/predicates")
+        response = requests.get("http://localhost:5000/api/predicates")
         print response.json()
 
 * From `httpie <https://github.com/jkbrzt/httpie>`_:
 
     .. sourcecode:: console
 
-        $ http GET http://localhost:5000/predicates
+        $ http GET http://localhost:5000/api/predicates
 
 * From `curl <http://curl.haxx.se/>`_:
 
     .. sourcecode:: console
 
-        $ curl http://localhost:5000/predicates
+        $ curl http://localhost:5000/api/predicates
 
 
 List equivalent identifiers
@@ -174,17 +174,17 @@ List equivalent identifiers
     .. sourcecode:: python
 
         import requests
-        response = requests.get("http://localhost:5000/eqids")
+        response = requests.get("http://localhost:5000/api/eqids")
         print response.json()
 
 * From `httpie <https://github.com/jkbrzt/httpie>`_:
 
     .. sourcecode:: console
 
-        $ http GET http://localhost:5000/eqids
+        $ http GET http://localhost:5000/api/eqids
 
 * From `curl <http://curl.haxx.se/>`_:
 
     .. sourcecode:: console
 
-        $ curl http://localhost:5000/eqids
+        $ curl http://localhost:5000/api/eqids

--- a/tests/test_eq_ids.py
+++ b/tests/test_eq_ids.py
@@ -71,7 +71,7 @@ def test_new_equivalence(webtest_app, dummy_claim, dummy_subject,
         assert 'No row was found for one' in str(excinfo)
 
     webtest_app.post_json(
-        '/claims',
+        '/api/claims',
         dummy_claim
     )
 
@@ -110,7 +110,7 @@ def test_new_subject(webtest_app, dummy_claim, dummy_subject, dummy_object):
 
     # Posting new claim
     webtest_app.post_json(
-        '/claims',
+        '/api/claims',
         dummy_claim
     )
 
@@ -153,7 +153,7 @@ def test_new_object(webtest_app, dummy_claim, dummy_subject, dummy_object):
 
     # Posting new claim
     webtest_app.post_json(
-        '/claims',
+        '/api/claims',
         dummy_claim
     )
 
@@ -190,7 +190,7 @@ def test_existing_subject_object(webtest_app, dummy_claim, dummy_subject,
     dummy_subject['value'] = sub_value
     dummy_object['value'] = ob_value
     webtest_app.post_json(
-        '/claims',
+        '/api/claims',
         dummy_claim
     )
     sub_eq = EquivalentIdentifier.query.filter_by(
@@ -215,7 +215,7 @@ def test_existing_subject_object(webtest_app, dummy_claim, dummy_subject,
     assert random_eq.eqid != sub_eq.eqid
 
     webtest_app.post_json(
-        '/claims',
+        '/api/claims',
         dummy_claim
     )
     # After the previous claim submission, all the eqids equivalent to the

--- a/tests/test_restful_api.py
+++ b/tests/test_restful_api.py
@@ -34,20 +34,32 @@ pytest_plugins = (
 
 @pytest.mark.usefixtures('all_predicates')
 def test_put_claimant(webtest_app, dummy_claimant):
-    """Testing `subscribe` api."""
+    """Testing `claimants` api."""
     resp = webtest_app.post_json(
-        '/api/subscribe',
+        '/api/claimants',
         dummy_claimant
     )
     assert resp.status_code == 200
 
     # Re-adding the same claimant should fail.
     resp = webtest_app.post_json(
-        '/api/subscribe',
+        '/api/claimants',
         dummy_claimant,
         expect_errors=True
     )
     assert resp.status_code == 400
+
+
+@populate_all
+def test_get_claimants(webtest_app):
+    """Testing GET claimants api."""
+    resp = webtest_app.get('/api/claimants')
+    assert resp.status_code == 200
+    assert len(resp.json) >= 2
+    claimant_uuid = list(resp.json)[0]['uuid']
+    resp = webtest_app.get('/api/claimants/{}'.format(claimant_uuid))
+    assert resp.status_code == 200
+    assert len(resp.json) == 1
 
 
 @pytest.mark.usefixtures('all_predicates')
@@ -63,7 +75,7 @@ def test_put_claim(webtest_app, dummy_claimant, dummy_claim):
 
     # Test when there is a claimant.
     webtest_app.post_json(
-        '/api/subscribe',
+        '/api/claimants',
         dummy_claimant
     )
     resp = webtest_app.post_json(
@@ -78,6 +90,10 @@ def test_get_claims(webtest_app):
     """Testing GET claims api."""
     resp = webtest_app.get('/api/claims')
     assert resp.status_code == 200
+    claim_uuid = list(resp.json)[0]['uuid']
+    resp = webtest_app.get('/api/claims/{}'.format(claim_uuid))
+    assert resp.status_code == 200
+    assert len(resp.json) == 1
 
 
 @populate_all

--- a/tests/test_restful_api.py
+++ b/tests/test_restful_api.py
@@ -36,14 +36,14 @@ pytest_plugins = (
 def test_put_claimant(webtest_app, dummy_claimant):
     """Testing `subscribe` api."""
     resp = webtest_app.post_json(
-        '/subscribe',
+        '/api/subscribe',
         dummy_claimant
     )
     assert resp.status_code == 200
 
     # Re-adding the same claimant should fail.
     resp = webtest_app.post_json(
-        '/subscribe',
+        '/api/subscribe',
         dummy_claimant,
         expect_errors=True
     )
@@ -55,7 +55,7 @@ def test_put_claim(webtest_app, dummy_claimant, dummy_claim):
     """Testing POST to `claims` api."""
     # Firstly we need a claimant, so the claim submission should fail.
     resp = webtest_app.post_json(
-        '/claims',
+        '/api/claims',
         dummy_claim,
         expect_errors=True
     )
@@ -63,11 +63,11 @@ def test_put_claim(webtest_app, dummy_claimant, dummy_claim):
 
     # Test when there is a claimant.
     webtest_app.post_json(
-        '/subscribe',
+        '/api/subscribe',
         dummy_claimant
     )
     resp = webtest_app.post_json(
-        '/claims',
+        '/api/claims',
         dummy_claim
     )
     assert resp.status_code == 200
@@ -76,7 +76,7 @@ def test_put_claim(webtest_app, dummy_claimant, dummy_claim):
 @populate_all
 def test_get_claims(webtest_app):
     """Testing GET claims api."""
-    resp = webtest_app.get('/claims')
+    resp = webtest_app.get('/api/claims')
     assert resp.status_code == 200
 
 
@@ -84,11 +84,11 @@ def test_get_claims(webtest_app):
 def test_get_claims_by_claimant(webtest_app):
     """Testing GET claims filtering by claimant."""
     # There are 1 CDS claim and 2 INSPIRE claims
-    resp = webtest_app.get('/claims')
+    resp = webtest_app.get('/api/claims')
     assert len(resp.json) == 3
-    resp = webtest_app.get('/claims?claimant=CDS')
+    resp = webtest_app.get('/api/claims?claimant=CDS')
     assert len(resp.json) == 1
-    resp = webtest_app.get('/claims?claimant=INSPIRE')
+    resp = webtest_app.get('/api/claims?claimant=INSPIRE')
     assert len(resp.json) == 2
 
 
@@ -96,11 +96,11 @@ def test_get_claims_by_claimant(webtest_app):
 def test_get_claims_by_predicate(webtest_app):
     """Testing GET claims filtering by predicate."""
     # There are 2 claims is_same_as and 1 is_variant_of
-    resp = webtest_app.get('/claims')
+    resp = webtest_app.get('/api/claims')
     assert len(resp.json) == 3
-    resp = webtest_app.get('/claims?predicate=is_same_as')
+    resp = webtest_app.get('/api/claims?predicate=is_same_as')
     assert len(resp.json) == 2
-    resp = webtest_app.get('/claims?predicate=is_variant_of')
+    resp = webtest_app.get('/api/claims?predicate=is_variant_of')
     assert len(resp.json) == 1
 
 
@@ -108,13 +108,13 @@ def test_get_claims_by_predicate(webtest_app):
 def test_get_claims_by_certainty(webtest_app):
     """Testing GET claims filtering by certainty."""
     # There are 3 claims with: 0.5, 0.8 and 1 as certainty.
-    resp = webtest_app.get('/claims?certainty=0.1')
+    resp = webtest_app.get('/api/claims?certainty=0.1')
     assert len(resp.json) == 3
-    resp = webtest_app.get('/claims?certainty=0.5')
+    resp = webtest_app.get('/api/claims?certainty=0.5')
     assert len(resp.json) == 3
-    resp = webtest_app.get('/claims?certainty=0.8')
+    resp = webtest_app.get('/api/claims?certainty=0.8')
     assert len(resp.json) == 2
-    resp = webtest_app.get('/claims?certainty=1')
+    resp = webtest_app.get('/api/claims?certainty=1')
     assert len(resp.json) == 1
 
 
@@ -122,13 +122,13 @@ def test_get_claims_by_certainty(webtest_app):
 def test_get_claims_by_c(webtest_app):
     """Testing GET claims filtering by certainty."""
     # There are 3 claims with: 0.5, 0.8 and 1 as certainty.
-    resp = webtest_app.get('/claims?certainty=0.1')
+    resp = webtest_app.get('/api/claims?certainty=0.1')
     assert len(resp.json) == 3
-    resp = webtest_app.get('/claims?certainty=0.5')
+    resp = webtest_app.get('/api/claims?certainty=0.5')
     assert len(resp.json) == 3
-    resp = webtest_app.get('/claims?certainty=0.8')
+    resp = webtest_app.get('/api/claims?certainty=0.8')
     assert len(resp.json) == 2
-    resp = webtest_app.get('/claims?certainty=1')
+    resp = webtest_app.get('/api/claims?certainty=1')
     assert len(resp.json) == 1
 
 
@@ -136,9 +136,9 @@ def test_get_claims_by_c(webtest_app):
 def test_get_claims_by_human(webtest_app):
     """Testing GET claims filtering by human."""
     # There are 2 human reported claims and 1 by an algorithm.
-    resp = webtest_app.get('/claims?human=0')
+    resp = webtest_app.get('/api/claims?human=0')
     assert len(resp.json) == 1
-    resp = webtest_app.get('/claims?human=1')
+    resp = webtest_app.get('/api/claims?human=1')
     assert len(resp.json) == 2
 
 
@@ -146,9 +146,9 @@ def test_get_claims_by_human(webtest_app):
 def test_get_claims_by_actor(webtest_app):
     """Testing GET claims filtering by actor."""
     # There are 2 actors: John Doe (2 times) and CDS_submission (1).
-    resp = webtest_app.get('/claims?actor=John%')
+    resp = webtest_app.get('/api/claims?actor=John%')
     assert len(resp.json) == 2
-    resp = webtest_app.get('/claims?actor=CDS%sub%')
+    resp = webtest_app.get('/api/claims?actor=CDS%sub%')
     assert len(resp.json) == 1
 
 
@@ -156,16 +156,16 @@ def test_get_claims_by_actor(webtest_app):
 def test_get_claims_by_type_value(webtest_app):
     """Testing GET claims filtering by type."""
     # There are 2 CDS_RECORD_ID, one as subject and one as an object.
-    resp = webtest_app.get('/claims?type=CDS_RECORD_ID')
+    resp = webtest_app.get('/api/claims?type=CDS_RECORD_ID')
     assert len(resp.json) == 2
     # The type with value `2003192` can be found 2 times.
-    resp = webtest_app.get('/claims?value=2003192')
+    resp = webtest_app.get('/api/claims?value=2003192')
     assert len(resp.json) == 2
     # Filter by type and value
-    resp = webtest_app.get('/claims?type=CDS_RECORD_ID&value=2003192')
+    resp = webtest_app.get('/api/claims?type=CDS_RECORD_ID&value=2003192')
     assert len(resp.json) == 2
     # Filter by non-existant
-    resp = webtest_app.get('/claims?type=NO_TYPE&value=2003192')
+    resp = webtest_app.get('/api/claims?type=NO_TYPE&value=2003192')
     assert len(resp.json) == 0
 
 
@@ -173,11 +173,11 @@ def test_get_claims_by_type_value(webtest_app):
 def test_get_claims_by_type_value_recursive(webtest_app):
     """Testing GET claims filtering by type."""
     resp = webtest_app.get(
-        '/claims?type=INSPIRE_RECORD_ID&value=cond-mat/9906097'
+        '/api/claims?type=INSPIRE_RECORD_ID&value=cond-mat/9906097'
     )
     assert len(resp.json) == 1
     resp = webtest_app.get(
-        '/claims?type=INSPIRE_RECORD_ID&value=cond-mat/9906097&recurse=1'
+        '/api/claims?type=INSPIRE_RECORD_ID&value=cond-mat/9906097&recurse=1'
     )
     assert len(resp.json) == 2
 
@@ -185,12 +185,12 @@ def test_get_claims_by_type_value_recursive(webtest_app):
 @populate_all
 def test_get_claims_by_subject_object(webtest_app):
     """Testing GET claims filtering by subject/object."""
-    resp = webtest_app.get('/claims?subject=CDS_RECORD_ID')
+    resp = webtest_app.get('/api/claims?subject=CDS_RECORD_ID')
     assert len(resp.json) == 1
-    resp = webtest_app.get('/claims?object=CDS_REPORT_NUMBER')
+    resp = webtest_app.get('/api/claims?object=CDS_REPORT_NUMBER')
     assert len(resp.json) == 1
     resp = webtest_app.get(
-        '/claims?subject=CDS_RECORD_ID&object=CDS_REPORT_NUMBER'
+        '/api/claims?subject=CDS_RECORD_ID&object=CDS_REPORT_NUMBER'
     )
     assert len(resp.json) == 1
 
@@ -198,7 +198,7 @@ def test_get_claims_by_subject_object(webtest_app):
 @populate_all
 def test_get_identifiers(webtest_app):
     """Testing GET identifiers api."""
-    resp = webtest_app.get('/identifiers')
+    resp = webtest_app.get('/api/identifiers')
     assert resp.status_code == 200
     assert len(resp.json) >= 7
 
@@ -206,7 +206,7 @@ def test_get_identifiers(webtest_app):
 @populate_all
 def test_get_predicates(webtest_app):
     """Testing GET predicates api."""
-    resp = webtest_app.get('/predicates')
+    resp = webtest_app.get('/api/predicates')
     assert resp.status_code == 200
     assert len(resp.json) == 5
 
@@ -214,10 +214,10 @@ def test_get_predicates(webtest_app):
 @populate_all
 def test_get_eqids(webtest_app):
     """Testing GET eqids api."""
-    resp = webtest_app.get('/eqids')
+    resp = webtest_app.get('/api/eqids')
     assert resp.status_code == 200
     assert len(resp.json) >= 2
     eqid = list(resp.json)[0]
-    resp = webtest_app.get('/eqids/{}'.format(eqid))
+    resp = webtest_app.get('/api/eqids/{}'.format(eqid))
     assert resp.status_code == 200
     assert len(resp.json) == 1


### PR DESCRIPTION
* Refactors Claimant Resoruce by renaming `subscribe` as `claimants`.
  (closes #101)

* Adds `GET /api/claimants/<uuid:claimant_id>`.

* Adds optinal `<uuid:claim_id>` to `GET /api/claims/`

Signed-off-by: Jose Benito Gonzalez Lopez <jose.benito.gonzalez@cern.ch>