### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,7 +1,7 @@
 Authors
 -------
 
-Contact us at `info@invenio-software.org <mailto:info@invenio-software.org>`_
+Contact us at `info@inveniosoftware.org <mailto:info@inveniosoftware.org>`_
 
 * Jose Benito Gonzalez Lopez <jose.benito.gonzalez@cern.ch>
 * Tibor Simko <tibor.simko@cern.ch>

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     url='https://github.com/inveniosoftware/claimstore',
     license='GPLv3',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     description=__doc__,
     long_description=open('README.rst', 'rt').read(),
     packages=['claimstore'],


### PR DESCRIPTION
- Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko tibor.simko@cern.ch
